### PR TITLE
Updates to sbank-balance to use local *_usage files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2016-05-13  Paddy Doyle <paddy@tchpc.tcd.ie>
+	* Version: 1.4.1
+	* src/_sbank-balance.pl: Change the way usage data is pulled out
+	  of the system: change from 'sreport' to 'sshare', which means
+	  pulling from local *_usage files instead of the SlurmDBD. Also
+	  provide for SlurmDBD reports with the '-s' param. Code refactor
+	  to use functions. Tweak command-line args. Fail gracefully if
+	  the accountname doesn't exist.
+	* src/sbank-*: Use path prefix SLURMBANK_DIR for all slurm-bank
+	  sub-commands.
+
 2013-06-06  Paddy Doyle <paddy@tchpc.tcd.ie>
 	* Version: 1.3.2
 	* src/_sbank-balance.pl: Add a '-s yyyy-mm-dd' start-date parameter

--- a/README
+++ b/README
@@ -11,8 +11,8 @@ if they do not have hours in their account then they cannot run jobs.
 
 Requirements (tested with)
 
-* SLURM 2.2.0, 2.2.7, 2.4.1, 2.5.3
-* Scientificlinux 5.x (bash, rsync, perl)
+* SLURM 2.2.0, 2.2.7, 2.4.1, 2.5.3, 2.6.x, 14.11.x, 15.08.x
+* Scientific Linux 5.x, 6.x (bash, rsync, perl)
 
 Source and Documentation
 ========================

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-slurm-bank-1.3.2
+slurm-bank-1.4.1

--- a/doc/sbank-balance.mdwn
+++ b/doc/sbank-balance.mdwn
@@ -25,7 +25,7 @@ then sbank-balance will show the balance of the user who ran the script.
 
   -a
 
-  display unformatted balance of account 'accountname' (defaults to
+  display balance of account 'accountname' (defaults to
   all accounts of the current user)
 
   -A
@@ -33,10 +33,23 @@ then sbank-balance will show the balance of the user who ran the script.
   display all accounts (defaults to all accounts of the
   current user)
 
-  -u
+  -U
 
   display only the current user's balances (defaults to all users
   in all accounts of the current user)
+
+  -u
+
+  display for the given user (defaults to the current user)
+
+  -b
+
+  display unformatted balance of account 'accountname'
+
+  -s
+
+  display historical user/account usage from the DBD via 'sreport',
+  starting from yyyy-mm-dd
 
 * request - request a number hours from an account and returns a number
   of hours remaining in the account.
@@ -70,17 +83,21 @@ then sbank-balance will show the balance of the user who ran the script.
 
 # EXAMPLES
 
-Show your own balance, including those of other members of the account
+Show your own balance (all your accounts), including those of other members of the accounts
 
 	sbank balance statement
 
-Show your own balance
+Show your own balance (all your accounts)
 
-	sbank balance statement -u
+	sbank balance statement -U
+
+Show the balance in the given account, including those of other members of the accounts
+
+	sbank balance statement -a account_name
 
 Show the unformatted balance of an account
 
-	sbank balance statement -a account_name
+	sbank balance statement -b account_name
 
 Show the balance of all accounts in the given cluster
 
@@ -99,6 +116,7 @@ to run a job.
 # AUTHOR
 
 Jimmy Tang <jtang@tchpc.tcd.ie>
+Paddy Doyle <paddy@tchpc.tcd.ie>
 
 # COPYRIGHT
 

--- a/slurm-bank.spec
+++ b/slurm-bank.spec
@@ -1,7 +1,7 @@
 # Pass --without docs to rpmbuild if you don't want the documentation
 
 Name:           slurm-bank
-Version:        1.3.2
+Version:        1.4.1
 Release:        2%{?dist}
 Summary:        SLURM Bank, a collection of wrapper scripts to do banking
 

--- a/src/_sbank-balance.pl
+++ b/src/_sbank-balance.pl
@@ -11,12 +11,13 @@
 # previous versions.
 # 
 # Requires 'sacctmgr' and 'sreport', and requires a SlurmDBD.
-# 
-# Note this is a re-write of the previous version, which used 'sshare' to
-# obtain usage information. The 'sshare' command reads from local usage
-# files, whereas as 'sreport' reads from the SlurmDBD. Specifically, 'sshare'
-# values will decay if half-life decay is enabled, while 'sreport' values
-# will not decay, and so give an actual usage.
+#
+# The default reports scrape the usage data from local *_usage files (via
+# sshare); these will report the usage (which may have been Decayed or
+# Reset) and the available Balance (if there is a Limit set on the account).
+#
+# The tool can also give a report of historical usage from the SlurmDBD (via
+# sreport); no limits or balance are reported in this case, just usage.
 # 
 
 # TODO:

--- a/src/_sbank-balance.pl
+++ b/src/_sbank-balance.pl
@@ -38,7 +38,7 @@ my $showallusers = 1;
 my $showallaccs = 0;
 my $clustername = "";
 my $accountname = "";
-my ($account, $user, $rawusage, $prev_acc);
+my ($account, $user, $prev_acc);
 my $sreport_start = "";
 my $sreport_end   = "";
 my $SREPORT_START_OFFSET = 94608000;	# 3 * 365 days, in seconds
@@ -105,6 +105,7 @@ sub print_results( $$$ ) {
 
 	my @account_list = sort keys %user_usage_per_acc;
 	my $first_iter   = 1;
+	my $rawusage;
 
 	if ($include_root) {
 		# instead of a purely sorted list, show the 'ROOT' account first (assuming
@@ -233,6 +234,8 @@ sub query_sreport_user_and_account_usage( $$$ ) {
 	my $account_param    = shift;
 	my $balance_only     = shift;
 	my $thisuser_only    = shift;
+
+	my $rawusage;
 
 	my $cluster_str = ($clustername ne "") ? "clusters=$clustername " : "";
 	my $query_str = "sreport -t minutes -np cluster AccountUtilizationByUser start=$sreport_start end=$sreport_end $cluster_str account=$account_param ";
@@ -448,8 +451,6 @@ if ($showallusers && $accountname ne "") {
 
 	#my $cluster_str = ($clustername ne "") ? "-M $clustername " : "";
 	my $cluster_str = ($clustername ne "") ? "clusters=$clustername " : "";
-
-	$rawusage = "";	# init to a value to stop perl warnings
 
 	# get the usage value, for all single given account
 	query_sreport_user_and_account_usage($accountname, 1, "");

--- a/src/_sbank-balance.pl
+++ b/src/_sbank-balance.pl
@@ -285,7 +285,7 @@ sub query_sshare_user_and_account_usage( $$$ ) {
 
 	my $rawusage;
 
-	my $cluster_str = ($clustername ne "") ? "clusters=$clustername " : "";
+	my $cluster_str = ($clustername ne "") ? "-M $clustername " : "";
 	my $user_str  = ($thisuser_only ne "") ? "" : "-a ";
 
 	my $query_str = "sshare -hp $cluster_str $user_str -A $account_param ";

--- a/src/_sbank-balance.pl
+++ b/src/_sbank-balance.pl
@@ -51,12 +51,12 @@ my $SREPORT_END_OFFSET   = 172800;	# 2 days to avoid DST issues, in seconds
 #####################################################################
 sub usage() {
 	print "Usage:\n";
-	print "$0 [-h] [-c clustername] [-b accountname] [-A accountname] [-a] [-u username] [-U] [-s yyyy-mm-dd]\n";
+	print "$0 [-h] [-c clustername] [-b accountname] [-a accountname] [-A] [-u username] [-U] [-s yyyy-mm-dd]\n";
 	print "\t-h:\tshow this help message\n";
 	print "\t-c:\treport on cluster 'clustername' (defaults to the local cluster)\n";
 	print "\t-b:\treport unformatted balance of account 'accountname'\n";
-	print "\t-A:\treport balance of account 'accountname' (defaults to all accounts of the current user)\n";
-	print "\t-a:\treport all accounts (defaults to all accounts of the current user)\n";
+	print "\t-a:\treport balance of account 'accountname' (defaults to all accounts of the current user)\n";
+	print "\t-A:\treport all accounts (defaults to all accounts of the current user)\n";
 	print "\t-U:\treport only the current user's balances (defaults to all users in all accounts of the current user)\n";
 	print "\t-u:\treport information for the given username, instead of the current user\n";
 	die   "\t-s:\treport historical user/account usage from the DBD via 'sreport', starting from yyyy-mm-dd\n";
@@ -360,7 +360,7 @@ sub query_sshare_user_and_account_usage( $$$ ) {
 # get options
 #####################################################################
 my %opts;
-getopts('hc:b:A:au:Us:', \%opts) || usage();
+getopts('hc:b:a:Au:Us:', \%opts) || usage();
 
 if (defined($opts{h})) {
 	usage();
@@ -376,11 +376,11 @@ if (defined($opts{b})) {
 	$accountname = "\U$opts{b}"; # normalise account names to uppercase
 }
 
-if (defined($opts{A})) {
-	$accountname = "\U$opts{A}"; # normalise account names to uppercase
+if (defined($opts{a})) {
+	$accountname = "\U$opts{a}"; # normalise account names to uppercase
 }
 
-if (defined($opts{a})) {
+if (defined($opts{A})) {
 	$showallaccs = 1;
 }
 

--- a/src/sbank-balance
+++ b/src/sbank-balance
@@ -3,16 +3,18 @@
 
 usage() 
 {
-	echo "usage: sbank balance statement -c CLUSTER -a ACCOUNT -A -u"
+	echo "usage: sbank balance statement [-c clustername] [-b accountname] [-a accountname] [-A] [-u username] [-U] [-s yyyy-mm-dd]"
 	echo "   or: sbank balance request -c CLUSTER -a ACCOUNT -t TIME -v"
 	echo "   or: sbank balance checkscript -c CLUSTER -s SCRIPT -v"
 	echo 
 	echo "options for 'statement'"
-	echo "        -a display unformatted balance of account 'accountname' (defaults to all accounts of the current user)"
-	echo "        -A display all accounts (defaults to all accounts of the current user)"
-	echo "        -u display only the current user's balances (defaults to all users in all accounts of the current user)"
-	echo "        -U display information for the given username, instead of the current user"
-	echo "        -s report usage starting from yyyy-mm-dd, instead of 3 years ago"
+	echo "        -c:     report on cluster 'clustername' (defaults to the local cluster)"
+	echo "        -b:     report unformatted balance of account 'accountname'"
+	echo "        -a:     report balance of account 'accountname' (defaults to all accounts of the current user)"
+	echo "        -A:     report all accounts (defaults to all accounts of the current user)"
+	echo "        -U:     report only the current user's balances (defaults to all users in all accounts of the current user)"
+	echo "        -u:     report information for the given username, instead of the current user"
+	echo "        -s:     report historical user/account usage from the DBD via 'sreport', starting from yyyy-mm-dd"
 	echo
 	echo "options for 'request'"
 	echo "        -a specify account"
@@ -47,11 +49,12 @@ cmd_statement()
 	# define some variables
 	debug "define some variables"
 	DEFINE_string 'account' '' 'specify a slurm account' 'a'
+	DEFINE_string 'account2' '' 'specify a slurm account for unformatted balance' 'b'
 	DEFINE_string 'cluster' '' 'specify a cluster' 'c'
-	DEFINE_string 'user' '' 'specify a username' 'U'
+	DEFINE_string 'user' '' 'specify a username' 'u'
 	DEFINE_string 'startdate' '' 'specify a start-date yyyy-mm-dd' 's'
 	DEFINE_boolean 'all' false 'show all users in the account' 'A'
-	DEFINE_boolean 'useronly' false 'show only the current user' 'u'
+	DEFINE_boolean 'useronly' false 'show only the current user' 'U'
 
 	FLAGS_PARENT="sbank balance statement"
 
@@ -64,10 +67,11 @@ cmd_statement()
 
 	[ "${FLAGS_cluster}" != "" ]  && opts="$opts -c ${FLAGS_cluster}"
 	[ "${FLAGS_account}" != "" ]  && opts="$opts -a ${FLAGS_account}"
-	[ "${FLAGS_user}" != "" ]  && opts="$opts -U ${FLAGS_user}"
+	[ "${FLAGS_account2}" != "" ]  && opts="$opts -b ${FLAGS_account2}"
+	[ "${FLAGS_user}" != "" ]  && opts="$opts -u ${FLAGS_user}"
 	[ "${FLAGS_startdate}" != "" ]  && opts="$opts -s ${FLAGS_startdate}"
 	[ ${FLAGS_all} -eq ${FLAGS_TRUE} ] && opts="$opts -A"
-	[ ${FLAGS_useronly} -eq ${FLAGS_TRUE} ] && opts="$opts -u"
+	[ ${FLAGS_useronly} -eq ${FLAGS_TRUE} ] && opts="$opts -U"
 
 	_sbank-balance.pl $opts
 }
@@ -115,7 +119,7 @@ cmd_request()
 	fi
 
 	# the balance account - this could be re-worked in a more clever way and check for exitcodes
-	balance_initial=`sbank balance statement -a ${FLAGS_account} -u`
+	balance_initial=`sbank balance statement -b ${FLAGS_account}`
 	debug "${balance_initial} hours is in the balance of ${FLAGS_account} on ${FLAGS_cluster}"
 
 	balance_post=`echo "${balance_initial} - ${FLAGS_time}" | bc`
@@ -139,7 +143,7 @@ cmd_request()
 		then
 			echo ${balance_post}
 		else
-			warn "The project does not have enough time to complete your request"
+			warn "The account does not have enough time to complete your request"
 			echo ${balance_post}
 		fi
 	fi

--- a/src/sbank-balance
+++ b/src/sbank-balance
@@ -73,7 +73,7 @@ cmd_statement()
 	[ ${FLAGS_all} -eq ${FLAGS_TRUE} ] && opts="$opts -A"
 	[ ${FLAGS_useronly} -eq ${FLAGS_TRUE} ] && opts="$opts -U"
 
-	_sbank-balance.pl $opts
+	$SLURMBANK_DIR/_sbank-balance.pl $opts
 }
 
 cmd_request()
@@ -100,7 +100,7 @@ cmd_request()
 	#[ "${FLAGS_account}" = "" ]  && die "must specify account"
 	if [ -z "${FLAGS_account}" ]
 	then
-		FLAGS_account=$(sbank user account)
+		FLAGS_account=$($SLURMBANK_DIR/sbank user account)
 
 		# if no default, then error
 		if [ -z "${FLAGS_account}" ]
@@ -114,15 +114,15 @@ cmd_request()
 
 	if [ "${FLAGS_cluster}" = "" ]
 	then
-		FLAGS_cluster=$(sbank cluster list)
+		FLAGS_cluster=$($SLURMBANK_DIR/sbank cluster list)
 		debug "using local cluster: ${FLAGS_cluster}"
 	fi
 
 	# the balance account - this could be re-worked in a more clever way and check for exitcodes
-	balance_initial=`sbank balance statement -b ${FLAGS_account}`
+	balance_initial=$($SLURMBANK_DIR/sbank balance statement -b ${FLAGS_account})
 	debug "${balance_initial} hours is in the balance of ${FLAGS_account} on ${FLAGS_cluster}"
 
-	balance_post=`echo "${balance_initial} - ${FLAGS_time}" | bc`
+	balance_post=$(echo "${balance_initial} - ${FLAGS_time}" | bc)
 
 	debug "${balance_post} hours remaining in balance after the request"
 
@@ -181,7 +181,7 @@ cmd_checkscript()
 
 	if [ "${FLAGS_cluster}" = "" ]
 	then
-		FLAGS_cluster=$(sbank cluster list)
+		FLAGS_cluster=$($SLURMBANK_DIR/sbank cluster list)
 		debug "using local cluster: ${FLAGS_cluster}"
 	fi
 
@@ -213,25 +213,25 @@ cmd_checkscript()
 	[ -z "$tasks" -a -z "$nodes" ] && die "at least one of tasks (-n) or nodes (-N) must be set in the script"
 
 
-	wall_hours=$(sbank time calc -t $walltime)
+	wall_hours=$($SLURMBANK_DIR/sbank time calc -t $walltime)
 
 	if [ -n "$tasks" ]
 	then
-		cpu_hours=$(sbank time estimate -n $tasks -t $wall_hours)
+		cpu_hours=$($SLURMBANK_DIR/sbank time estimate -n $tasks -t $wall_hours)
 	elif [ -n "$nodes" ]
 	then
 		if [ -z "$cpus" ]
 		then
-			cpus=$(sbank cluster cpupernode)
+			cpus=$($SLURMBANK_DIR/sbank cluster cpupernode)
 			warn "no cores-per-node specified - estimating $cpus"
 		fi
-		cpu_hours=$(sbank time estimate -N $nodes -c $cpus -t $wall_hours)
+		cpu_hours=$($SLURMBANK_DIR/sbank time estimate -N $nodes -c $cpus -t $wall_hours)
 	fi
 
 	# if no account, look for default
 	if [ -z "$acc" ]
 	then
-		acc=$(sbank user account)
+		acc=$($SLURMBANK_DIR/sbank user account)
 
 		# if no default, then error
 		if [ -z "$acc" ]
@@ -244,9 +244,9 @@ cmd_checkscript()
 
 	if [ ${FLAGS_verbose} -eq ${FLAGS_TRUE} ]
 	then
-		sbank balance request -a $acc -c ${FLAGS_cluster} -t $cpu_hours -v
+		$SLURMBANK_DIR/sbank balance request -a $acc -c ${FLAGS_cluster} -t $cpu_hours -v
 	else
-		sbank balance request -a $acc -c ${FLAGS_cluster} -t $cpu_hours
+		$SLURMBANK_DIR/sbank balance request -a $acc -c ${FLAGS_cluster} -t $cpu_hours
 	fi
 }
 

--- a/src/sbank-cluster
+++ b/src/sbank-cluster
@@ -124,12 +124,12 @@ cmd_cpuhrs() {
 	then
 		FLAGS_cluster="-M ${FLAGS_cluster}"
 	else
-		FLAGS_cluster="-M $(sbank cluster list)"
+		FLAGS_cluster="-M $($SLURMBANK_DIR/sbank cluster list)"
 	fi
 
 	for i in year month week day
 	do
-		_sbank-common-cpu_hrs.pl -t hours -i $i ${FLAGS_cluster}
+		$SLURMBANK_DIR/_sbank-common-cpu_hrs.pl -t hours -i $i ${FLAGS_cluster}
 	done
 }
 

--- a/src/sbank-deposit
+++ b/src/sbank-deposit
@@ -47,7 +47,7 @@ cmd_deposit()
 	if [ "${FLAGS_time}" -gt "0" ];
 	then
 		# the account limit - this could be re-worked in a more clever way and check for exitcodes
-		LIMIT=`$SACCTMGR -np list associations cluster=${FLAGS_cluster} format=account,GrpCPUMins account=${FLAGS_account} | head -1 | awk -F'|' '{print $2}'`
+		LIMIT=$($SACCTMGR -np list associations cluster=${FLAGS_cluster} format=account,GrpCPUMins account=${FLAGS_account} | head -1 | awk -F'|' '{print $2}')
 		debug "${LIMIT}mins is the limit of ${FLAGS_account} on ${FLAGS_cluster}"
 
 		# new limit is the old limit +/- a delta

--- a/src/sbank-refund
+++ b/src/sbank-refund
@@ -48,10 +48,10 @@ cmd_job()
 	jobtime_slurm=$(sacct -n --format elapsed%30 -j "${FLAGS_jobid}")
 	debug "elapsed time from sacct $jobtime_slurm"
 
-	jobtime_hours=$(sbank time calc -t $jobtime_slurm)
+	jobtime_hours=$($SLURMBANK_DIR/sbank time calc -t $jobtime_slurm)
 	debug "elapsed time from sacct in hours $jobtime_hours"
 
-	sbank deposit -a $account -t $jobtime_hours -c $(sbank cluster list)
+	$SLURMBANK_DIR/sbank deposit -a $account -t $jobtime_hours -c $(sbank cluster list)
 }
 
 cmd_help()

--- a/src/sbank-submit
+++ b/src/sbank-submit
@@ -34,9 +34,9 @@ cmd_submit()
         [ ! -r "${FLAGS_scriptname}" ]  && die "unable to read: ${FLAGS_scriptname}"
 
 	log "Getting balance for ${USER}"
-	sbank balance statement
+	$SLURMBANK_DIR/sbank balance statement
 	log "Checking script before submitting"
-	sbank balance checkscript -s ${FLAGS_scriptname} -v
+	$SLURMBANK_DIR/sbank balance checkscript -s ${FLAGS_scriptname} -v
 	log "sbatch'ing the script"
 	sbatch ${FLAGS_scriptname}
 }

--- a/src/sbank-time
+++ b/src/sbank-time
@@ -135,10 +135,10 @@ cmd_calc()
 	# now do the cals
 
 	# call 'bc' because bash doesn't do floating point!
-	float=`echo "scale=2; ($days*86400 + $hours*3600 + $mins*60 + $secs) / 3600" | bc`
+	float=$(echo "scale=2; ($days*86400 + $hours*3600 + $mins*60 + $secs) / 3600" | bc)
 	# and call printf because bc doesn't round numbers!
 	debug "rounded to the nearest hour:"
-	wallhours=`printf "%.0f\n" $float`
+	wallhours=$(printf "%.0f\n" $float)
 
 	# final check - if it has been rounded down to 0 wall hours, make it 1 (this is only
 	# an estimate anyway
@@ -189,7 +189,7 @@ cmd_estimate()
 		[ "${FLAGS_nodes}" -le "0" ] && die "nodes must be greater than 0"
 		if [ "${FLAGS_cores}" -le "0" ]
 		then
-			FLAGS_cores=$(sbank cluster cpupernode)
+			FLAGS_cores=$($SLURMBANK_DIR/sbank cluster cpupernode)
 			warn "no cores-per-node specified - estimating $cpus"
 		fi
 		printf "$(( ${FLAGS_nodes} * ${FLAGS_cores} * ${FLAGS_time} ))\n"
@@ -251,19 +251,19 @@ cmd_estimatescript()
 	[ -z "$tasks" -a -z "$nodes" ] && die "at least one of tasks (-n) or nodes (-N) must be set in the script"
 
 
-	wall_hours=$(sbank time calc -t $walltime)
+	wall_hours=$($SLURMBANK_DIR/sbank time calc -t $walltime)
 
 	if [ -n "$tasks" ]
 	then
-		cpu_hours=$(sbank time estimate -n $tasks -t $wall_hours)
+		cpu_hours=$($SLURMBANK_DIR/sbank time estimate -n $tasks -t $wall_hours)
 	elif [ -n "$nodes" ]
 	then
 		if [ -z "$cpus" ]
 		then
-			cpus=$(sbank cluster cpupernode)
+			cpus=$($SLURMBANK_DIR/sbank cluster cpupernode)
 			warn "no cores-per-node specified - estimating $cpus"
 		fi
-		cpu_hours=$(sbank time estimate -N $nodes -c $cpus -t $wall_hours)
+		cpu_hours=$($SLURMBANK_DIR/sbank time estimate -N $nodes -c $cpus -t $wall_hours)
 	fi
 
 	if [ ${FLAGS_verbose} -eq ${FLAGS_TRUE} ]

--- a/src/sbank-version
+++ b/src/sbank-version
@@ -1,4 +1,4 @@
-SBANK_VERSION=1.3.2
+SBANK_VERSION=1.4.1
 
 usage() 
 {


### PR DESCRIPTION
Revert previous update (1.3) of using the slurmdbd for usage values. This turned out to not be useful, since slurm uses the local *_usage files itself for calculating when a job has available resources (rather than the historical data from slurmdbd). Hence with the slurmdbd/sreport usage values, the balance figure was completely inaccurate.
By using the local *_usage files, Decay and Reset parameters in the slurm.conf still make sense -- it will still show meaningful Limit and Available Balance figures.
The historical usage from slurmdbd/sreport is still available in the tool, just not as the default; you can ask for the historical usage report from a given start date.
Plus lots of small code improvements / tidy-ups.